### PR TITLE
4-1【C】Circle CIによりpush時に単体テストが自動で実行されるようになっていること

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 executors:
-  java11: 
+  j11: 
     docker:
       - image: cimg/openjdk:11.0
 orbs:
@@ -10,4 +10,4 @@ workflows:
   maven_test:
     jobs:
       - maven/test:
-        executor: java11
+          executor: j11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+executors:
+  java11: 
+    docker:
+      - image: cimg/openjdk:11.0
+orbs:
+  maven: circleci/maven@1.2.0
+version: 2.1
+
+workflows:
+  maven_test:
+    jobs:
+      - maven/test:
+        executor: java11

--- a/src/test/java/com/raisetech/RingoResTfulApiApplicationTests.java
+++ b/src/test/java/com/raisetech/RingoResTfulApiApplicationTests.java
@@ -1,6 +1,6 @@
 package com.raisetech;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+// import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,10 +12,10 @@ class RingoRESTfulApiApplicationTests {
 	void contextLoads() {
 	}
 
-	@Test
-	void テスト失敗時の動作確認用テスト(){
-		int expect = 1;
-		int actual = 2;
-		assertEquals( expect , actual);
-	}
+// 	@Test
+// 	void テスト失敗時の動作確認用テスト(){
+// 		int expect = 1;
+// 		int actual = 2;
+// 		assertEquals( expect , actual);
+// 	}
 }

--- a/src/test/java/com/raisetech/RingoResTfulApiApplicationTests.java
+++ b/src/test/java/com/raisetech/RingoResTfulApiApplicationTests.java
@@ -1,13 +1,21 @@
 package com.raisetech;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class RingoResTfulApiApplicationTests {
+class RingoRESTfulApiApplicationTests {
 
 	@Test
 	void contextLoads() {
 	}
 
+	@Test
+	void テスト失敗時の動作確認用テスト(){
+		int expect = 1;
+		int actual = 2;
+		assertEquals( expect , actual);
+	}
 }


### PR DESCRIPTION
## 概要

- Push時にJUnitによる単体テストが動作するようにCircleCI環境を構築しました。
- mergeの際にCircleCIで実行したテストをpassしなければmergeできないように設定しました。
- 5/28 りんごチーム内では動作確認済み。

## 関連issue
[4-1【C】Circle CIによりpush時に単体テストが自動で実行されるようになっていること](https://github.com/raisetech-for-student/ringo-crud-restfulapi/issues/9)

## 動作確認画面
- test passの場合のCircleCI動作確認
![image](https://user-images.githubusercontent.com/83934720/170812765-5bc42032-0511-4b61-80b6-985e9a0bee67.png)
![image](https://user-images.githubusercontent.com/83934720/170812822-0a248dd0-4403-4276-9a52-1c81e6729916.png)

- test passの場合のPR時動作確認
![image](https://user-images.githubusercontent.com/83934720/170812992-71e61c77-39e5-4eea-8f88-7a630570d840.png)

- test Failedの場合のCircleCI動作確認
![image](https://user-images.githubusercontent.com/83934720/170825174-df3d0047-22c3-4201-b27a-ea615dea3369.png)
![image](https://user-images.githubusercontent.com/83934720/170825206-5b4d7281-d3eb-4828-be0d-491876a049bf.png)

- test Failedの場合のPR時動作確認
![image](https://user-images.githubusercontent.com/83934720/170825337-d7cb6e55-b71e-4a45-b6e9-60c008b642b3.png)

